### PR TITLE
Refactor to make the code more idiomatic

### DIFF
--- a/src/bada.rs
+++ b/src/bada.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::env;
 use std::path::Path;
 use std::process::ExitCode;
+use std::rc::Rc;
 
 #[macro_use]
 mod diag;
@@ -9,33 +10,33 @@ mod compiler;
 mod lex;
 mod parser;
 
-use parser::Module;
+use crate::parser::Module;
 
 fn main() -> ExitCode {
     let mut args = env::args();
     let program = args.next().expect("program");
 
-    let input_path = if let Some(input_path) = args.next() {
-        input_path
-    } else {
-        eprintln!("Usage: {program} <bada.boom>");
-        eprintln!("ERROR: no input is provided");
-        return ExitCode::FAILURE;
-    };
-
-    let output_path = Path::new(&input_path).with_extension("beam");
-
-    let content: Vec<_> = match fs::read_to_string(&input_path) {
-        Ok(content) => content.chars().collect(),
-        Err(err) => {
-            eprintln!("ERROR: could not load file {input_path}: {err}");
+    let input_path: Rc<Path> = match args.next() {
+        Some(input_path) => Rc::from(Path::new(input_path.as_str())),
+        None => {
+            eprintln!("Usage: {program} <bada.boom>");
+            eprintln!("ERROR: no input is provided");
             return ExitCode::FAILURE;
         }
     };
-    let mut lexer = lex::Lexer::new(&content, input_path.clone());
-    let module = if let Some(module) = Module::parse(&mut lexer) {
-        module
-    } else {
+
+    let output_path = input_path.with_extension("beam");
+
+    let content: Vec<_> = match fs::read_to_string(input_path.as_ref()) {
+        Ok(content) => content.chars().collect(),
+        Err(err) => {
+            eprintln!("ERROR: could not load file {0}: {err}", input_path.display());
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let mut lexer = lex::Lexer::new(content, input_path);
+    let Some(module) = Module::parse(&mut lexer) else {
         return ExitCode::FAILURE;
     };
 
@@ -45,12 +46,17 @@ fn main() -> ExitCode {
     bytes.extend((beam.len() as u32).to_be_bytes());
     bytes.extend(beam);
 
-    if let Err(err) = fs::write(&output_path, &bytes) {
-        eprintln!("ERROR: Could not write file {output_path}: {err}", output_path = output_path.display());
-        return ExitCode::FAILURE;
+
+    match fs::write(&output_path, &bytes) {
+        Ok(()) => {
+            println!("INFO: Generated {0}", output_path.display());
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            eprintln!("ERROR: Could not write file {0}: {err}", output_path.display());
+            ExitCode::FAILURE
+        }
     }
-    println!("INFO: Generated {output_path}", output_path = output_path.display());
-    ExitCode::SUCCESS
 }
 
 // TODO: implement BEAM disassembler as part of bada compiler

--- a/src/bada.rs
+++ b/src/bada.rs
@@ -42,7 +42,7 @@ fn main() -> ExitCode {
 
     let beam = compiler::compile_beam_module(&module);
     let mut bytes: Vec<u8> = Vec::new();
-    bytes.extend("FOR1".as_bytes());
+    bytes.extend(b"FOR1");
     bytes.extend((beam.len() as u32).to_be_bytes());
     bytes.extend(beam);
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,6 +1,5 @@
-use diag::*;
 use std::collections::HashMap;
-use parser::{Expr, Module, Func, BinopKind, Binop, Param};
+use crate::parser::{Expr, Module, Func, BinopKind, Binop, Param};
 
 #[repr(u8)]
 enum Tag {
@@ -60,7 +59,7 @@ fn encode_chunk(tag: [u8; 4], chunk: Vec<u8>) -> Vec<u8> {
     result
 }
 
-
+// FIXME: too much parametres
 fn compile_expr(expr: &Expr, atoms: &mut Atoms, imports: &HashMap<(u32, u32, u32), u32>, code: &mut Vec<u8>, params: &HashMap<String, Param>, stack_size: &mut usize) -> Option<()> {
     let stack_start = params.len();
     match expr {

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -1,20 +1,19 @@
+use std::path::Path;
+use std::rc::Rc;
+
 pub struct Loc {
-    pub file_path: String,
+    pub file_path: Rc<Path>,
     pub row: usize,
     pub col: usize,
 }
 
 macro_rules! report {
     ($loc:expr, $level:literal, $fmt:literal) => {
-        let Loc{file_path, row, col} = $loc;
-        let level = $level;
-        eprint!("{file_path}:{row}:{col}: {level}: ");
+        eprint!("{}:{}:{}: {}: ", $loc.file_path.display(), $loc.row, $loc.col, $level);
         eprintln!($fmt);
     };
     ($loc:expr, $level:literal, $fmt:literal, $($args:tt)*) => {
-        let Loc{file_path, row, col} = $loc;
-        let level = $level;
-        eprint!("{file_path}:{row}:{col}: {level}: ");
+        eprint!("{}:{}:{}: {}: ", $loc.file_path.display(), $loc.row, $loc.col, $level);
         eprintln!($fmt, $($args)*);
     };
 }

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -1,4 +1,8 @@
-use diag::Loc;
+use std::path::Path;
+use std::fmt::Display;
+use std::rc::Rc;
+
+use crate::diag::Loc;
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum TokenKind {
@@ -27,9 +31,9 @@ const FIXED_TOKENS: &[(&[char], TokenKind)] = &[
     (&[')'], TokenKind::ClosedParen),
 ];
 
-impl TokenKind {
-    fn human(&self) -> &str {
-        match self {
+impl Display for TokenKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
             Self::Ident => "identifier",
             Self::Number => "number",
 
@@ -43,7 +47,7 @@ impl TokenKind {
 
             Self::End => "end of input",
             Self::Unknown => "unknown token",
-        }
+        })
     }
 }
 
@@ -53,20 +57,25 @@ pub struct Token {
     pub loc: Loc,
 }
 
-pub struct Lexer<'a> {
-    content: &'a [char],
-    file_path: String,
+// I use Rc<Path> instead of the previous String, because `String::clone` has
+// a big cost, Path is made to represent file path (like str to represent
+// string) and Rc owned only 1 paths and not 10,000
+pub struct Lexer {
+    content: Vec<char>,
+    file_path: Rc<Path>,
     pos: usize,
     bol: usize,
     row: usize,
 }
 
-impl<'a> Lexer<'a> {
-    pub fn new(content: &'a [char], file_path: String) -> Self {
-        Self {content, file_path, pos: 0, bol: 0, row: 0}
+impl Lexer {
+    pub fn new(content: Vec<char>, file_path: Rc<Path>) -> Self {
+        Self { content, file_path, pos: 0, bol: 0, row: 0 }
     }
 
-    pub fn expect_tokens(&mut self, expected_kinds: &[TokenKind]) -> Option<Token> {
+    pub fn expect_tokens<E: AsRef<[TokenKind]>>(&mut self, expected_kinds: E) -> Option<Token> {
+        let expected_kinds = expected_kinds.as_ref();
+
         let token = self.next_token();
         for kind in expected_kinds {
             if token.kind == *kind {
@@ -74,19 +83,16 @@ impl<'a> Lexer<'a> {
             }
         }
 
-        let mut expected_list = String::new();
-        for (i, kind) in expected_kinds.iter().enumerate() {
-            if i == 0 {
-                expected_list.push_str(&format!("{}", kind.human()))
-            } else if i + 1 >= expected_kinds.len() {
-                expected_list.push_str(&format!(", or {}", kind.human()))
-            } else {
-                expected_list.push_str(&format!(", {}", kind.human()))
-            }
-        }
+        let expected_list = expected_kinds.iter().enumerate()
+            .fold(String::new(), |acc, (i, kind)| {
+                match i {
+                    0 => format!("{kind}"),
+                    x if x < expected_kinds.len() - 1 => format!("{acc}, {kind}"),
+                    _ => format!("{acc}, or {kind}")
+                }
+            });
 
-        report!(token.loc, "ERROR", "Expected {expected_list}, but got {actual}",
-                actual = token.kind.human());
+        report!(token.loc, "ERROR", "Expected {expected_list}, but got {}", token.kind);
         None
     }
 
@@ -104,6 +110,7 @@ impl<'a> Lexer<'a> {
     }
 
     fn next_token(&mut self) -> Token {
+        // TODO: move into it's owned function
         'trim_whitespaces_and_comments: loop {
             self.trim_whitespaces();
             if self.starts_with(&['/', '/']) {
@@ -114,71 +121,72 @@ impl<'a> Lexer<'a> {
         }
 
         let loc = Loc {
-            file_path: self.file_path.clone(),
+            file_path: Rc::clone(&self.file_path),
             row: self.row + 1,
             col: self.pos - self.bol + 1,
         };
 
-        let x = if let Some(x) = self.current_char() {
-            x
-        } else {
-            return Token {
+        match self.current_char() {
+            // TODO: move into it's owned function
+            Some(x) if x.is_alphabetic() => {
+                let mut text = String::new();
+                while let Some(x) = self.current_char() {
+                    if x.is_alphanumeric() {
+                        self.chop_char();
+                        text.push(x);
+                    } else {
+                        break;
+                    }
+                }
+                
+                Token {
+                    text,
+                    loc,
+                    kind: TokenKind::Ident,
+                }
+            },
+            // TODO: move into it's owned function
+            Some(x) if x.is_numeric() => {
+                let mut text = String::new();
+                while let Some(x) = self.current_char() {
+                    if x.is_numeric() {
+                        self.chop_char();
+                        text.push(x);
+                    } else {
+                        break;
+                    }
+                }
+                
+                Token {
+                    text,
+                    loc,
+                    kind: TokenKind::Number,
+                }
+            },
+            Some(x) => 'fixed_tokens: {
+                for &(prefix, kind) in FIXED_TOKENS.iter() {
+                    if self.starts_with(prefix) {
+                        self.chop_chars(prefix.len());
+                        break 'fixed_tokens Token {
+                            text: prefix.iter().collect(),
+                            loc,
+                            kind,
+                        }
+                    }
+                }
+
+                self.chop_char();
+                Token {
+                    text: x.to_string(),
+                    loc,
+                    kind: TokenKind::Unknown,
+                }
+            }
+            None => Token {
                 text: "".to_string(),
                 loc,
                 kind: TokenKind::End,
             }
-        };
-
-        if x.is_alphabetic() {
-            let mut text = String::new();
-            while let Some(x) = self.current_char() {
-                if x.is_alphanumeric() {
-                    self.chop_char();
-                    text.push(x);
-                } else {
-                    break;
-                }
-            }
-            return Token {
-                text,
-                loc,
-                kind: TokenKind::Ident,
-            }
-        }
-
-        if x.is_numeric() {
-            let mut text = String::new();
-            while let Some(x) = self.current_char() {
-                if x.is_numeric() {
-                    self.chop_char();
-                    text.push(x);
-                } else {
-                    break;
-                }
-            }
-            return Token {
-                text,
-                loc,
-                kind: TokenKind::Number,
-            }
-        }
-
-        for &(prefix, kind) in FIXED_TOKENS.iter() {
-            if self.starts_with(prefix) {
-                self.chop_chars(prefix.len());
-                return Token {
-                    text: prefix.iter().collect(),
-                    loc,
-                    kind,
-                }
-            }
-        }
-
-        self.chop_char();
-        Token {
-            text: x.to_string(),
-            loc,
-            kind: TokenKind::Unknown,
         }
     }
 
@@ -193,9 +201,10 @@ impl<'a> Lexer<'a> {
     }
 
     fn chop_char(&mut self) {
-        if let Some(x) = self.current_char() {
+        // to avoid unnecessary clone
+        if let Some(x) = self.content.get(self.pos) {
             self.pos += 1;
-            if x == '\n' {
+            if *x == '\n' {
                 self.row += 1;
                 self.bol = self.pos;
             }


### PR DESCRIPTION
This is a refactor to make the code more idiomatic (even if the code works in the previous version, this refactored version is intended to make the rust code "clearer" and closer to code written by someone used to the language).

The aim of this pr is not to change the code enormously or add new features, but more to make idiomatic changes. All major changes (such as the `file_path` which changes from `String` to `Rc<Path>`) will be justified or justifiable (if justification has been forgotten). Some comments will be added to give tips for more understandable (and idiomatic ^^', I'm thinking of `let mut module = Module::default();` in the `parser.rs` file) code, but of course this is nothing mandatory. 

(the refactor isn't finished yet)